### PR TITLE
add: gitleaks-fullscan & observability options

### DIFF
--- a/docs/admin/infra_aws.md
+++ b/docs/admin/infra_aws.md
@@ -11,7 +11,7 @@ RISKENをAWS上に構築する上で以下の項目が必要になります
 - AWS環境について
     - 本ドキュメントでは以下のAWS環境での構築例を記載します（該当しない箇所は適宜手順の修正が必要です）
         - リージョン: `ap-northeast-1`
-        - EKSバージョン: 1.21
+        - EKSバージョン: 1.21+
 - OIDCをサポートしているIdP
     - RISKENのユーザ認証は外部のIdPと連携します
     - 認証フローの詳細について[AWS ELBドキュメント :octicons-link-external-24:](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html#configure-user-authentication){ target="_blank" } を参照してください

--- a/docs/admin/infra_aws_option.md
+++ b/docs/admin/infra_aws_option.md
@@ -4,6 +4,15 @@ AWSのマネージドサービスとの連携や、細かなチューニング�
 
 ---
 
+## Observability
+
+AWSのObservability関連の各種サービスと連携することが可能です。詳細は下記のAWSドキュメントを参照ください
+
+- [Amazon EKS と Kubernetes での Container Insights のセットアップ :octicons-link-external-24:](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-EKS.html){ target="_blank" }
+- [CloudWatch Logs へログを送信する DaemonSet として Fluent Bit を設定する :octicons-link-external-24:](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs-FluentBit.html){ target="_blank" }
+
+---
+
 ## Pod単位でIAMロールを設定する
 
 - AWS EKSではKubernetes内のサービスアカウントとIAMロールを紐付けることにより、Pod単位での細かなアクセスコントロールが可能になります


### PR DESCRIPTION
- `gitlekas-full-scan` をオプションとして説明する形に修正
- AWSのオプションページに`Observability` 関連の記述を追加（CWLエージェントなどのDaemonSetをk8s-sampleから削除したためドキュメントで補足）