### PR TITLE
rm: eks replace command

### DIFF
--- a/docs/admin/infra_aws.md
+++ b/docs/admin/infra_aws.md
@@ -195,10 +195,9 @@ $ aws eks --region ap-northeast-1 update-kubeconfig --name <cluster_name>
 $ git clone https://github.com/ca-risken/k8s-sample.git
 ```
 
-- EKS用のテンプレートをコピーし先程作成したクラスタ情報に置換します
+- EKS用のテンプレートをコピーします
 ```sell
 $ cp -r overlays/eks-template overlays/eks
-$ sed -i "" -e 's/your-cluster/<cluster_name>/g' overlays/eks/*.yaml
 ```
 
 - Kustomizeコマンドよりアプリケーションをデプロイします


### PR DESCRIPTION
CWLエージェント向けに必要だった以下のコマンドを削除（CWL出力はオプション扱いとしたため）

```bash
$ sed -i "" -e 's/your-cluster/<cluster_name>/g' overlays/eks/*.yaml
```
※↑の手順によってCloudWatchのLogGroup名が設定しようとしていました