### PR TITLE
fix: eks node minimum instaces

### DIFF
--- a/docs/admin/infra_aws.md
+++ b/docs/admin/infra_aws.md
@@ -93,7 +93,7 @@ RISKENをAWS上に構築する上で以下の項目が必要になります
 ```yaml
 - AMI type: `Amazon Linux 2 (AL2_x86_64)`
 - インスタンスタイプ: `t3.medium`
-- インスタンス数（Min）: 3
+- インスタンス数（Min）: 2
 ```
 
 ???+ tip "FargateタイプやGraviton2タイプのノードを使いたい"


### PR DESCRIPTION
デフォルトの構成で余計なものを色々削ったおかげで、最小ノード数を3->2に変更
（以前はDaemonSetなどが複数が立ち上がってノードあたりに確保しているIPアドレスの数が不足していた）