### PR TITLE
fix: aws policies

### DIFF
--- a/docs/aws/overview_iam.md
+++ b/docs/aws/overview_iam.md
@@ -15,7 +15,11 @@ AWSマネージメントコンソールからの設定例を記載します
             "Effect": "Allow",
             "Action": [
                 "ses:DescribeActiveReceiptRuleSet",
+                "athena:GetWorkGroup",
+                "logs:DescribeLogGroups",
+                "logs:DescribeMetricFilters",
                 "elastictranscoder:ListPipelines",
+                "elasticfilesystem:DescribeFileSystems",
                 "servicequotas:ListServiceQuotas"
             ],
             "Resource": "*"


### PR DESCRIPTION
[CloudSploit側のアップデート](https://github.com/aquasecurity/cloudsploit/blob/master/docs/aws.md)で以下のポリシーを追加します。

- athena:GetWorkGroup  (Athena)
- logs:DescribeLogGroups (CWL)
- logs:DescribeMetricFilters (CWL)
- elasticfilesystem:DescribeFileSystems (EFS)