### PR TITLE
fix example of policy

### DIFF
--- a/docs/risken/user.en.md
+++ b/docs/risken/user.en.md
@@ -46,6 +46,7 @@ Before creating a role, you need to set the **policy** that is associated with t
 
 - **Policy** defines what operations (actions) are allowed for data (resources).
 - It is possible to set multiple policies for a single role.
+- The policy is described in [regular expressions :octicons-link-external-24:](https://github.com/google/re2/wiki/Syntax). 
 
 ### Policy Setting
 
@@ -55,7 +56,7 @@ Before creating a role, you need to set the **policy** that is associated with t
 3. Enter the following in the policy dialog and click `REGIST`.
     - **Name**: Policy name
     - **Action Pattern**: Action name pattern
-        - For example, set `(get|list|describe|show)` for the ReadOnly action.
+        - For example, set `(get|list|is-admin|put-alert-first-viewed-at)` for the ReadOnly action.
     - **Resource Pattern**: Resource name pattern
         - *Currently, detailed control using resource patterns is not supported. Therefore, please specify `.*` in the Resource field. (Control will be uniformly at the project level.)
 

--- a/docs/risken/user.md
+++ b/docs/risken/user.md
@@ -50,6 +50,7 @@ RISKENへログインしたことのないユーザへ権限を割り当てる�
 
 - **ポリシー** とはデータ（リソース）に対して、どんな操作（アクション）を許可するかを定義したものです
 - １つのロールに対して複数のポリシーを設定することが可能です
+- ポリシーの記述には[正規表現  :octicons-link-external-24:](https://github.com/google/re2/wiki/Syntax)を使用しています
 
 ### ポリシー設定
 
@@ -59,7 +60,7 @@ RISKENへログインしたことのないユーザへ権限を割り当てる�
 3. ポリシーダイアログで以下を入力し`REGIST`をクリックします
     - **Name**: ポリシー名
     - **Action Pattern**: Action名のパターン
-        -   例えばReadOnly用のActionは`(get|list|describe|show)`を設定します
+        - 　例えばReadOnly用のActionは`(get|list|is-admin|put-alert-first-viewed-at)`を設定します
     - **Resource Pattern**: Resource名のパターン
         - ※ 現在細かいResourceパターンでの制御は未サポートです。そのため、Resource欄は`.*`で指定してください。（一律プロジェクト単位での制御となります）
 


### PR DESCRIPTION

デフォルトロールの追加に伴い、ReadOnlyロールのポリシー例を変更します。また、ポリシーを記述する際に何を使用すればいいのかわからなかったので、正規表現という記述を増やしました。

<img width="947" alt="image" src="https://github.com/ca-risken/doc/assets/44151180/5d3c7ce4-c577-44b1-ab5d-0d26ecdc6a3a">
<img width="1004" alt="image" src="https://github.com/ca-risken/doc/assets/44151180/dbfb1d9d-282f-485f-b060-93848e5ece44">

動作確認済みです。観点としては文言や正規表現という記述が必要かどうかについてお願いいたします。
