### PR TITLE
fix: ssmDocumentPublicAccess score

### DIFF
--- a/docs/aws/cloudsploit.en.md
+++ b/docs/aws/cloudsploit.en.md
@@ -140,6 +140,5 @@ In addition, compliance tags for standards such as CIS and PCIDSS are assigned d
 |SageMaker|notebookDirectInternetAccess|0.6|||
 |SES|dkimEnabled|0.6||Updated 2021/06/17|
 |SNS|topicPolicies|0.8||Updated 2021/06/17|
-|SSM|ssmDocumentPublicAccess|0.8||Updated 2023/04/11|
 |SQS|sqsPublicAccess|0.6|||
 |Transfer|transferLoggingEnabled|0.6|hipaa, pci|Updated 2021/06/17|

--- a/docs/aws/cloudsploit.md
+++ b/docs/aws/cloudsploit.md
@@ -139,6 +139,5 @@ graph TD
 |SageMaker|notebookDirectInternetAccess|0.6|||
 |SES|dkimEnabled|0.6||2021/06/17更新|
 |SNS|topicPolicies|0.8||2021/06/17更新|
-|SSM|ssmDocumentPublicAccess|0.8||2023/04/11更新|
 |SQS|sqsPublicAccess|0.6|||
 |Transfer|transferLoggingEnabled|0.6|hipaa, pci|2021/06/17更新|


### PR DESCRIPTION
ssmDocumentPublicAccessのスコアを変更したいです。
内容的にはS3のパブリックアクセスブロックと同じかと思いますので、そちらにあわせて0.3でどうでしょうか？