### PR TITLE
[mod]risken-sa-permissions

### DIFF
--- a/docs/google/overview_sa.en.md
+++ b/docs/google/overview_sa.en.md
@@ -54,6 +54,7 @@ title: "RISKEN"
 description: "RISKEN custom role."
 stage: "GA"
 includedPermissions:
+- apikeys.keys.list
 - cloudasset.assets.analyzeIamPolicy
 - cloudasset.assets.listResource
 - cloudasset.assets.searchAllIamPolicies
@@ -93,7 +94,6 @@ includedPermissions:
 - compute.globalAddresses.list
 - compute.globalForwardingRules.get
 - compute.globalForwardingRules.list
-- compute.globalForwardingRules.pscGet
 - compute.globalNetworkEndpointGroups.get
 - compute.globalNetworkEndpointGroups.list
 - compute.globalOperations.get
@@ -145,11 +145,7 @@ includedPermissions:
 - compute.machineImages.list
 - compute.machineTypes.get
 - compute.machineTypes.list
-- compute.maintenancePolicies.get
-- compute.maintenancePolicies.getIamPolicy
-- compute.maintenancePolicies.list
 - compute.networkEndpointGroups.get
-- compute.networkEndpointGroups.getIamPolicy
 - compute.networkEndpointGroups.list
 - compute.networks.get
 - compute.networks.getEffectiveFirewalls
@@ -201,7 +197,6 @@ includedPermissions:
 - compute.routes.get
 - compute.routes.list
 - compute.securityPolicies.get
-- compute.securityPolicies.getIamPolicy
 - compute.securityPolicies.list
 - compute.snapshots.get
 - compute.snapshots.getIamPolicy
@@ -345,7 +340,6 @@ includedPermissions:
 - networksecurity.locations.list
 - networksecurity.operations.list
 - networksecurity.serverTlsPolicies.list
-- networkservices.endpointConfigSelectors.list
 - networkservices.httpFilters.list
 - networkservices.httpfilters.list
 - networkservices.locations.list

--- a/docs/google/overview_sa.md
+++ b/docs/google/overview_sa.md
@@ -58,6 +58,7 @@ title: "RISKEN"
 description: "RISKEN custom role."
 stage: "GA"
 includedPermissions:
+- apikeys.keys.list
 - cloudasset.assets.analyzeIamPolicy
 - cloudasset.assets.listResource
 - cloudasset.assets.searchAllIamPolicies
@@ -97,7 +98,6 @@ includedPermissions:
 - compute.globalAddresses.list
 - compute.globalForwardingRules.get
 - compute.globalForwardingRules.list
-- compute.globalForwardingRules.pscGet
 - compute.globalNetworkEndpointGroups.get
 - compute.globalNetworkEndpointGroups.list
 - compute.globalOperations.get
@@ -149,11 +149,7 @@ includedPermissions:
 - compute.machineImages.list
 - compute.machineTypes.get
 - compute.machineTypes.list
-- compute.maintenancePolicies.get
-- compute.maintenancePolicies.getIamPolicy
-- compute.maintenancePolicies.list
 - compute.networkEndpointGroups.get
-- compute.networkEndpointGroups.getIamPolicy
 - compute.networkEndpointGroups.list
 - compute.networks.get
 - compute.networks.getEffectiveFirewalls
@@ -205,7 +201,6 @@ includedPermissions:
 - compute.routes.get
 - compute.routes.list
 - compute.securityPolicies.get
-- compute.securityPolicies.getIamPolicy
 - compute.securityPolicies.list
 - compute.snapshots.get
 - compute.snapshots.getIamPolicy
@@ -349,7 +344,6 @@ includedPermissions:
 - networksecurity.locations.list
 - networksecurity.operations.list
 - networksecurity.serverTlsPolicies.list
-- networkservices.endpointConfigSelectors.list
 - networkservices.httpFilters.list
 - networkservices.httpfilters.list
 - networkservices.locations.list


### PR DESCRIPTION
RISKENの権限について、以下を追加
```
resourcemanager.organizations.get
resourcemanager.folders.list
resourcemanager.projects.list
apikeys.keys.list
```

また、廃止された権限を削除
```
廃止された権限または非表示の権限
これらの権限は廃止されたか、非表示になっているため、カスタムロールに関して有効にならない可能性があります。これらの権限を含むロールを更新すると、失敗する可能性があります。
compute.globalForwardingRules.pscGet
compute.maintenancePolicies.get
compute.maintenancePolicies.getIamPolicy
compute.maintenancePolicies.list
compute.networkEndpointGroups.getIamPolicy
compute.securityPolicies.getIamPolicy
networkservices.endpointConfigSelectors.list
```